### PR TITLE
ci: fetch tags

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Fetch tags
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          git fetch --prune --unshallow origin HEAD
       - name: Login to container image registry
         run: |
           echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com


### PR DESCRIPTION
Since b346396439d74, `git describe` is used to calculate the version of
the repository. However, this requires tags to be present. Since
`actions/checkout` performs a shallow clone, we need to explicitly do
this.

See: b346396439d74ffbe503f831bfce14bd38cc4461
See: https://github.com/actions/checkout/tree/94c2de77cccf605d74201a8aec6dd8fc0717ad66#Fetch-all-tags