### PR TITLE
images: `ulimit -n` to work-around `libtirpc` bug

### DIFF
--- a/images/nfs-ganesha/entrypoint.sh
+++ b/images/nfs-ganesha/entrypoint.sh
@@ -23,7 +23,7 @@ DBUS_DAEMON_UP=0
 for i in `seq 1 $TIMEOUT`; do
     echo "Waiting for rpcbind to be up ($i/$TIMEOUT)..."
     set +e
-    /usr/sbin/rpcinfo -T tcp 127.0.0.1 100000 4
+    ( ulimit -n 1024 && exec /usr/sbin/rpcinfo -T tcp 127.0.0.1 100000 4 )
     result=$?
     set -e
 
@@ -44,7 +44,7 @@ fi
 for i in `seq 1 $TIMEOUT`; do
     echo "Waiting for rpc.statd to be up ($i/$TIMEOUT)..."
     set +e
-    /usr/sbin/rpcinfo -T tcp 127.0.0.1 100024 1
+    ( ulimit -n 1024 && exec /usr/sbin/rpcinfo -T tcp 127.0.0.1 100024 1 )
     result=$?
     set -e
 

--- a/images/nfs-ganesha/healthcheck.sh
+++ b/images/nfs-ganesha/healthcheck.sh
@@ -7,6 +7,8 @@ HOST=127.0.0.1
 PROGRAM=100003
 VERSION=4
 
+ulimit -n 1024
+
 exec /usr/bin/timeout \
         --kill-after=1s \
         8s \

--- a/images/rpc.statd/entrypoint.sh
+++ b/images/rpc.statd/entrypoint.sh
@@ -24,12 +24,13 @@ TIMEOUT=10
 for i in `seq 1 $TIMEOUT`; do
     echo "Waiting for rpcbind to be up ($i/$TIMEOUT)..."
     set +e
-    /usr/bin/rpcinfo -T tcp 127.0.0.1 100000 4
+    ( ulimit -n 1024 && exec /usr/bin/rpcinfo -T tcp 127.0.0.1 100000 4 )
     result=$?
     set -e
 
     if [ $result -eq 0 ]; then
         echo "rpcbind listening, starting rpc.statd"
+        ulimit -n 1024
         exec /usr/sbin/rpc.statd --no-syslog --foreground --state-directory-path ${STATD_LIBDIR} ${PORT_ARG} "$@"
     fi
 

--- a/images/rpc.statd/healthcheck.sh
+++ b/images/rpc.statd/healthcheck.sh
@@ -7,6 +7,8 @@ HOST=127.0.0.1
 PROGRAM=100024
 VERSION=1
 
+ulimit -n 1024
+
 exec /usr/bin/timeout \
         --kill-after=1s \
         8s \

--- a/images/rpcbind/entrypoint.sh
+++ b/images/rpcbind/entrypoint.sh
@@ -3,5 +3,6 @@
 set -xue -o pipefail
 
 /usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/rpcbind.conf
+ulimit -n  1024
 
 exec /usr/bin/rpcbind "$@" -w -f

--- a/images/rpcbind/healthcheck.sh
+++ b/images/rpcbind/healthcheck.sh
@@ -7,6 +7,8 @@ HOST=127.0.0.1
 PROGRAM=100000
 VERSION=4
 
+ulimit -n 1024
+
 exec /usr/bin/timeout \
         --kill-after=1s \
         8s \


### PR DESCRIPTION
Code in `libtirpc` uses the current hard limit of number of open files
(`RLIMIT_NOFILE`) to allocate a buffer. Until recently, most systems ran
with a reasonable (low) limit set, e.g. 1024. However, recent `systemd`
changes raised the hard limit to, basically, unlimited, since system
resource consumption is now managed at system level (memory `cgroup`,
`kmem` accounting,...) instead of per resource type.

As a result, running an application that uses certain `libtirpc`
functionality, like `rpcinfo` but likely also `rpcbind` and `rpc.statd`
caused the application to be OOM-killed (rightfully so).

As a result, the `rpcinfo`-based entrypoint and healthcheck scripts for
containers built in this project are failing, and no service is
provided.

To work-around this, we now set a `nofile` limit of 1024 when running
`rpcbind` and `rpc.statd`, and also set such limit whenever `rpcinfo` is
invoked (in a subshell: we *don't* want to e.g., limit the number of
files NFS Ganesha can open later).

See: https://git.linux-nfs.org/?p=steved/libtirpc.git;a=blob;f=src/rpc_generic.c;hb=3642f9f6692bd8c0f4ac40561a27ef63502d80a4#l115
See: https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=99f943123d2832cdd0f77c989d82cc8cba26e90b
See: https://sourceforge.net/p/libtirpc/mailman/libtirpc-devel/thread/20200422162214.122039-1-steved%40redhat.com/#msg36989420
See: https://sourceforge.net/p/libtirpc/mailman/libtirpc-devel/thread/alpine.LSU.2.21.2004211333320.4323%40gibbons/#msg36987791
See: https://github.com/systemd/systemd/pull/15423
See: https://sourceforge.net/p/libtirpc/mailman/libtirpc-devel/thread/CAFjYY%2B%2BZftzKJ%3D%3D9qwhH93KfY1J5JMQbzbyhoH4t1Hv%3Ddc6HpQ%40mail.gmail.com/#msg36975310