### PR TITLE
ganesha-config-reload: remove `replace` from `go.mod`

### DIFF
--- a/ganesha-config-reload/go.mod
+++ b/ganesha-config-reload/go.mod
@@ -1,6 +1,6 @@
 module github.com/NicolasT/contained-ganesha/ganesha-config-reload
 
-go 1.14
+go 1.22
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0
@@ -9,6 +9,6 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	k8s.io/kubernetes v1.18.2
+	k8s.io/kubernetes v1.28.14
 	sigs.k8s.io/controller-runtime v0.6.0
 )

--- a/ganesha-config-reload/go.mod
+++ b/ganesha-config-reload/go.mod
@@ -12,27 +12,3 @@ require (
 	k8s.io/kubernetes v1.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace (
-	k8s.io/api => k8s.io/api v0.18.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.18.2
-	k8s.io/apiserver => k8s.io/apiserver v0.18.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.2
-	k8s.io/client-go => k8s.io/client-go v0.18.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.2
-	k8s.io/code-generator => k8s.io/code-generator v0.18.2
-	k8s.io/component-base => k8s.io/component-base v0.18.2
-	k8s.io/cri-api => k8s.io/cri-api v0.18.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
-	k8s.io/kubectl => k8s.io/kubectl v0.18.2
-	k8s.io/kubelet => k8s.io/kubelet v0.18.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2
-	k8s.io/metrics => k8s.io/metrics v0.18.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.2
-)


### PR DESCRIPTION
I kinda hope these are no longer required nowadays, allowing newer versions of various dependencies to be used.