### PR TITLE
deploy/podman: don't restart test container

### DIFF
--- a/deploy/podman/Makefile
+++ b/deploy/podman/Makefile
@@ -54,6 +54,7 @@ check-nobuild: $(MANIFEST) | up-local-nobuild ## Run 'podman play kube' using lo
 		--rm \
 		--pull=never \
 		--read-only \
+		--restart=no \
 		--cap-drop=ALL \
 		--cap-add=NET_BIND_SERVICE \
 		--pod=$(POD) \


### PR DESCRIPTION
When not passing the `--restart` flag, the test container would be rescheduled continuously, which is not the intent.